### PR TITLE
Enable albums page to work for much longer than one hour

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gphotos-albums",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "View all your Google Photos Albums using API",
   "private": true,
   "license": "Apache-2.0",

--- a/src/app/api/getAlbums/route.ts
+++ b/src/app/api/getAlbums/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
 
-import { libraryApiGetAlbums } from '@/lib/googleApi';
+import { PhotosApi } from '@/lib/googleApi';
 
 import { auth } from '@/auth';
 
@@ -8,35 +8,28 @@ export async function GET(request: NextRequest) {
   const session = await auth();
   if (!session?.user) return NextResponse.json({});
 
-  // TODO: figure out how to fix this type error after next-auth version 5.0 gets out of beta
-  // Property 'access_token' does not exist on type 'User'.
-  // @ts-expect-error: session.user.access_token created in session cb, see auth.ts
-  const access_token = session.user.access_token;
-  // @ts-expect-error: session.user.refresh_token created in session cb, see auth.ts
-  const refresh_token = session.user.refresh_token;
-
   let useCache = true;
   const params = request.nextUrl.searchParams;
   if (params.has('useCache')) {
     // added || '' to quiet Type error: Object is possibly 'null'.
     (params.get('useCache') || '').match(/^(0|false)$/) && (useCache = false);
   }
-  console.log('getAlbums', {
-    access_token: access_token,
-    refresh_token: refresh_token,
-    useCache: useCache,
-    session: session,
-  });
-
   // TODO: based on useCache, opt in/out of caching
   // https://nextjs.org/docs/14/app/building-your-application/routing/route-handlers#opting-out-of-caching
 
-  // if testing, use const data = getFakeAlbumsData();
+  // TODO: figure out how to fix this type error after next-auth version 5.0 gets out of beta
+  // Property 'access_token' does not exist on type 'User'.
+  const photosApi = new PhotosApi(
+    // @ts-expect-error: session.user.access_token created in session cb, see auth.ts
+    session.user.access_token,
+    // @ts-expect-error: session.user.refresh_token created in session cb, see auth.ts
+    session.user.refresh_token,
+    useCache
+    //session: session,
+  );
 
-  const data = await libraryApiGetAlbums(access_token);
-  if (401 == data.statusCode) {
-    console.log('getAlbums:401 need to refresh access_token');
-  }
+  // if testing, use photosApi.getFakeAlbumsData();
+  const data = await photosApi.libraryApiGetAlbums();
   if (data.error) {
     // Error occured during the request. Albums could not be loaded.
     console.log('getAlbums: libraryApiGetAlbums', data);

--- a/src/app/api/getAlbums/route.ts
+++ b/src/app/api/getAlbums/route.ts
@@ -12,6 +12,8 @@ export async function GET(request: NextRequest) {
   // Property 'access_token' does not exist on type 'User'.
   // @ts-expect-error: session.user.access_token created in session cb, see auth.ts
   const access_token = session.user.access_token;
+  // @ts-expect-error: session.user.refresh_token created in session cb, see auth.ts
+  const refresh_token = session.user.refresh_token;
 
   let useCache = true;
   const params = request.nextUrl.searchParams;
@@ -21,6 +23,7 @@ export async function GET(request: NextRequest) {
   }
   console.log('getAlbums', {
     access_token: access_token,
+    refresh_token: refresh_token,
     useCache: useCache,
     session: session,
   });
@@ -31,8 +34,12 @@ export async function GET(request: NextRequest) {
   // if testing, use const data = getFakeAlbumsData();
 
   const data = await libraryApiGetAlbums(access_token);
+  if (401 == data.statusCode) {
+    console.log('getAlbums:401 need to refresh access_token');
+  }
   if (data.error) {
     // Error occured during the request. Albums could not be loaded.
+    console.log('getAlbums: libraryApiGetAlbums', data);
     return NextResponse.json({
       error: 'Could not fetch from Google API, see logs',
     });

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -17,7 +17,7 @@ export const authConfig: NextAuthConfig = {
           access_type: 'offline', // should auto refresh access tokens
           response_type: 'code',
           scope:
-            // scope authorizes us to read google photos api.  New way in 2025
+            // scope authorizes us to read google photos api.  Changes in 2025
             // https://developers.google.com/identity/oauth2/web/guides/migration-to-gis#authorization-code-flow
             'openid profile email https://www.googleapis.com/auth/photoslibrary.readonly',
         },
@@ -41,6 +41,7 @@ export const authConfig: NextAuthConfig = {
       if (token && account?.refresh_token) {
         token.refresh_token ??= account.refresh_token;
       }
+      /*
       let rlen = 0;
       if (token.refresh_token && 'string' == typeof token.refresh_token) {
         rlen = token.refresh_token.length;
@@ -50,6 +51,7 @@ export const authConfig: NextAuthConfig = {
         alen = token.access_token.length;
       }
       console.debug(`jwt token ${rlen}r ${alen}a, ${JSON.stringify(token)}`);
+      */
       return token;
     },
     session({ session, token }) {
@@ -73,26 +75,22 @@ export const authConfig: NextAuthConfig = {
         // @ts-expect-error: Should be assignable
         session.user.refresh_token = token.refresh_token;
       }
-      console.debug(
-        'auth.ts session',
-        JSON.stringify({
-          token: token,
-          session: session,
-        })
-      );
+      //console.debug('auth.ts session', session);
       return session;
     },
   },
 };
 
 // import { type DefaultSession } from 'next-auth';
+// import { JWT } from "next-auth/jwt"
 //import type { AdapterUser } from 'next-auth/core/adapters';
 // Below module augmentation did not work for me, still had typescript errors with access_token
 // TODO: resolve after next-auth 5 is out of beta
 // similar fixed: https://github.com/nextauthjs/next-auth/issues/9253#issuecomment-2314104438
 //
+// export global {
 // https://authjs.dev/getting-started/typescript#module-augmentation
-// declare module 'next-auth' {
+//  module 'next-auth' {
 //   /**
 //    * Returned by `auth`, `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
 //    */
@@ -111,3 +109,5 @@ export const authConfig: NextAuthConfig = {
 //     } & DefaultSession['user'];
 //   }
 // }
+//
+// export {}; // you need to have an export statement, even if you are not exporting anything

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -41,11 +41,15 @@ export const authConfig: NextAuthConfig = {
       if (token && account?.refresh_token) {
         token.refresh_token ??= account.refresh_token;
       }
-      console.debug(
-        `jwt token ${token.refresh_token.length}r ${
-          token.access_token.length
-        }a, ${JSON.stringify(token)}`
-      );
+      let rlen: number = 0;
+      if (token.refresh_token && 'string' == typeof token.refresh_token) {
+        rlen = token.refresh_token.length;
+      }
+      let alen: number = 0;
+      if (token.access_token && 'string' == typeof token.access_token) {
+        alen = token.access_token.length;
+      }
+      console.debug(`jwt token ${rlen}r ${alen}a, ${JSON.stringify(token)}`);
       return token;
     },
     session({ session, token }) {

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -41,7 +41,11 @@ export const authConfig: NextAuthConfig = {
       if (token && account?.refresh_token) {
         token.refresh_token ??= account.refresh_token;
       }
-      console.debug('auth.ts jwt returning: token', JSON.stringify(token));
+      console.debug(
+        `jwt token ${token.refresh_token.length}r ${
+          token.access_token.length
+        }a, ${JSON.stringify(token)}`
+      );
       return token;
     },
     session({ session, token }) {

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -41,11 +41,11 @@ export const authConfig: NextAuthConfig = {
       if (token && account?.refresh_token) {
         token.refresh_token ??= account.refresh_token;
       }
-      let rlen: number = 0;
+      let rlen = 0;
       if (token.refresh_token && 'string' == typeof token.refresh_token) {
         rlen = token.refresh_token.length;
       }
-      let alen: number = 0;
+      let alen = 0;
       if (token.access_token && 'string' == typeof token.access_token) {
         alen = token.access_token.length;
       }

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -38,6 +38,9 @@ export const authConfig: NextAuthConfig = {
       if (token && account?.access_token) {
         token.access_token ??= account.access_token;
       }
+      if (token && account?.refresh_token) {
+        token.refresh_token ??= account.refresh_token;
+      }
       console.debug('auth.ts jwt returning: token', JSON.stringify(token));
       return token;
     },
@@ -54,6 +57,13 @@ export const authConfig: NextAuthConfig = {
         // similar fixed: https://github.com/nextauthjs/next-auth/issues/9253#issuecomment-2314104438
         // @ts-expect-error: Should be assignable
         session.user.access_token = token.access_token;
+      }
+      if (session.user && token.refresh_token) {
+        // TODO: figure out how to fix: Property 'refresh_token' does not exist on type 'AdapterUser & User'
+        // TODO: resolve after next-auth 5 is out of beta
+        // similar fixed: https://github.com/nextauthjs/next-auth/issues/9253#issuecomment-2314104438
+        // @ts-expect-error: Should be assignable
+        session.user.refresh_token = token.refresh_token;
       }
       console.debug(
         'auth.ts session',

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -14,7 +14,7 @@ export const authConfig: NextAuthConfig = {
       authorization: {
         params: {
           prompt: 'consent',
-          access_type: 'offline',
+          access_type: 'offline', // should auto refresh access tokens
           response_type: 'code',
           scope:
             // scope authorizes us to read google photos api.  New way in 2025

--- a/src/lib/googleApi.ts
+++ b/src/lib/googleApi.ts
@@ -155,21 +155,22 @@ export class PhotosApi {
 
   refreshAccessToken = async (): Promise<boolean> => {
     // https://developers.google.com/identity/protocols/oauth2/web-server#offline
+    const reqBody = {
+      client_id: this.client_id,
+      client_secret: this.client_secret,
+      refresh_token: this.refresh_token,
+      grant_type: 'refresh_token',
+    };
     const rawResponse = await fetch('https://oauth2.googleapis.com/token', {
       method: 'POST',
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        client_id: this.client_id,
-        client_secret: this.client_secret,
-        refresh_token: this.refresh_token,
-        grant_type: 'refresh_token',
-      }),
+      body: JSON.stringify(reqBody),
     });
-    console.log('refreshAccessToken rawResponse', rawResponse);
     const content = await rawResponse.json();
+    console.log('refreshAccessToken', rawResponse, content, reqBody);
     if (200 == rawResponse.status) {
       this.access_token = content.access_token;
       return true;

--- a/src/lib/googleApi.ts
+++ b/src/lib/googleApi.ts
@@ -18,6 +18,7 @@ interface AlbumData {
 }
 
 interface GetAlbumsReturn {
+  statusCode: number;
   albums: AlbumData[];
   error: string;
 }
@@ -31,6 +32,7 @@ export async function libraryApiGetAlbums(
   access_token: string
 ): Promise<GetAlbumsReturn> {
   const ret: GetAlbumsReturn = {
+    statusCode: 0,
     albums: [],
     error: '',
   };
@@ -57,6 +59,7 @@ export async function libraryApiGetAlbums(
           },
         }
       );
+      ret.statusCode = response.status;
       if (!response.ok) {
         const result = await response.json();
         console.warn('libraryApiGetAlbums - fetch not ok.');
@@ -115,6 +118,7 @@ export async function libraryApiGetAlbums(
  */
 export function getFakeAlbumsData(): GetAlbumsReturn {
   return {
+    statusCode: 200,
     albums: [
       {
         id: 'AC7OsWZSvKmd_BPEjRBdfHJ5K0MM4UdIqGjVgYLomvo7p7_ztWqDiMy4tSZuspFnS7z2E33Ny69t',

--- a/src/lib/googleApi.ts
+++ b/src/lib/googleApi.ts
@@ -82,7 +82,9 @@ export class PhotosApi {
     } catch (err) {
       // Log the error and prepare to return it.
       ret.error = JSON.stringify(err);
-      console.error(JSON.stringify({ 'libraryApiGetAlbums Error': err }));
+      console.error(
+        JSON.stringify({ 'libraryApiGetAlbums Error': err, err: ret.error })
+      );
     }
 
     console.debug(
@@ -93,6 +95,8 @@ export class PhotosApi {
   };
 
   fetchAlbums = async (parameters: URLSearchParams): Promise<Response> => {
+    console.log('fetchAlbums parameters:', parameters);
+
     const response = await fetch(
       apiConfig.apiEndpoint + '/v1/albums?' + parameters,
       {
@@ -126,8 +130,8 @@ export class PhotosApi {
     }
     if (!response.ok) {
       const result = await response.json();
-      console.warn('libraryApiGetAlbums - fetch not ok.');
-      console.debug('libraryApiGetAlbums - fetch not ok:', {
+      console.warn('libraryApiGetAlbums() fetch not ok.');
+      console.debug('libraryApiGetAlbums() fetch not ok:', {
         responseJson: result,
         response: response,
       });

--- a/src/lib/googleApi.ts
+++ b/src/lib/googleApi.ts
@@ -127,6 +127,7 @@ export class PhotosApi {
       }
     } else {
       console.log('fetchAlbums status is NOT 401');
+      await this.refreshAccessToken(); // TODO delme
     }
     if (!response.ok) {
       const result = await response.json();

--- a/src/lib/googleApi.ts
+++ b/src/lib/googleApi.ts
@@ -18,98 +18,157 @@ interface AlbumData {
 }
 
 interface GetAlbumsReturn {
-  statusCode: number;
   albums: AlbumData[];
   error: string;
 }
 
-/*
- * @description Calls the Google Photos API to get all albums
- * @param {string} access_token - token supplied by Google to use API
- * @returns {GetAlbumsReturn}
- */
-export async function libraryApiGetAlbums(
-  access_token: string
-): Promise<GetAlbumsReturn> {
-  const ret: GetAlbumsReturn = {
-    statusCode: 0,
-    albums: [],
-    error: '',
-  };
-  const parameters = new URLSearchParams();
-  parameters.append('pageSize', apiConfig.albumPageSize);
-  console.debug(
-    `Using API cmd: ${apiConfig.apiEndpoint}/v1/albums?${parameters}`
-  );
+export class PhotosApi {
+  authRetries = 1;
+  client_id = process.env.AUTH_GOOGLE_ID;
+  client_secret = process.env.AUTH_GOOGLE_SECRET;
 
-  try {
-    // Loop while there is a nextpageToken property in the response until all
-    // albums have been listed.
-    do {
-      console.debug(`Loading albums. Received so far: ${ret.albums.length}`);
-      // Make a GET request to load the albums with optional parameters (the
-      // pageToken if set).
-      const response = await fetch(
-        apiConfig.apiEndpoint + '/v1/albums?' + parameters,
-        {
-          method: 'get',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: 'Bearer ' + access_token,
-          },
-        }
-      );
-      ret.statusCode = response.status;
-      if (!response.ok) {
+  constructor(
+    public access_token: string,
+    public refresh_token: string,
+    public useCache: boolean
+  ) {}
+
+  /*
+   * @description Calls the Google Photos API to get all albums
+   * @param {string} access_token - token supplied by Google to use API
+   * @returns {GetAlbumsReturn}
+   */
+  libraryApiGetAlbums = async (): Promise<GetAlbumsReturn> => {
+    const ret: GetAlbumsReturn = {
+      albums: [],
+      error: '',
+    };
+    const parameters = new URLSearchParams();
+    parameters.append('pageSize', apiConfig.albumPageSize);
+    console.debug(
+      `Using API cmd: ${apiConfig.apiEndpoint}/v1/albums?${parameters}`
+    );
+
+    try {
+      // Loop while there is a nextpageToken property in the response until all
+      // albums have been listed.
+      do {
+        console.debug(`Loading albums. Received so far: ${ret.albums.length}`);
+        // Make a GET request to load the albums with optional parameters (the
+        // pageToken if set).
+        const response = await this.fetchAlbums(parameters);
+        //console.debug('libraryApiGetAlbums - fetch ok');
+
         const result = await response.json();
-        console.warn('libraryApiGetAlbums - fetch not ok.');
-        console.debug('libraryApiGetAlbums - fetch not ok:', {
-          responseJson: result,
-          response: response,
-        });
-        // Throw a StatusError if a non-OK HTTP status was returned.
-        let message = '';
-        try {
-          // Try to parse the response body as JSON, in case the server returned a useful response.
-          message = await response.json();
-        } catch (err) {
-          // Ignore if no JSON payload was retrieved and use the status text instead.
+
+        //console.debug('Response', result);
+
+        if (result && result.albums) {
+          //console.log(`Number of albums received: ${result.albums.length}`);
+          // Parse albums and add them to the list, skipping empty entries.
+          const items = result.albums.filter((x: AlbumData) => !!x);
+
+          ret.albums = ret.albums.concat(items);
         }
-        throw new Error(`${response.status} ${response.statusText} ${message}`);
+        if (result.nextPageToken) {
+          parameters.set('pageToken', result.nextPageToken);
+        } else {
+          parameters.delete('pageToken');
+        }
+
+        // Loop until all albums have been listed and no new nextPageToken is
+        // returned.
+      } while (parameters.has('pageToken'));
+    } catch (err) {
+      // Log the error and prepare to return it.
+      ret.error = JSON.stringify(err);
+      console.error(JSON.stringify({ 'libraryApiGetAlbums Error': err }));
+    }
+
+    console.debug(
+      JSON.stringify({ 'API response of first album': ret.albums[0] })
+    );
+    console.log(`${ret.albums.length} Albums loaded from Google Photos API`);
+    return ret;
+  };
+
+  fetchAlbums = async (parameters: URLSearchParams): Promise<Response> => {
+    const response = await fetch(
+      apiConfig.apiEndpoint + '/v1/albums?' + parameters,
+      {
+        method: 'get',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer ' + this.access_token,
+        },
       }
-      //console.debug('libraryApiGetAlbums - fetch ok');
-
-      const result = await response.json();
-
-      //console.debug('Response', result);
-
-      if (result && result.albums) {
-        //console.log(`Number of albums received: ${result.albums.length}`);
-        // Parse albums and add them to the list, skipping empty entries.
-        const items = result.albums.filter((x: AlbumData) => !!x);
-
-        ret.albums = ret.albums.concat(items);
-      }
-      if (result.nextPageToken) {
-        parameters.set('pageToken', result.nextPageToken);
+    );
+    if (401 == response.status) {
+      // unauthorized
+      if (this.authRetries--) {
+        const isRefreshed = await this.refreshAccessToken();
+        if (isRefreshed) {
+          return await this.fetchAlbums(parameters);
+        } else {
+          throw new Error(
+            '401 Unauthorized, could refresh token, maybe logout then login'
+          );
+        }
       } else {
-        parameters.delete('pageToken');
+        throw new Error(
+          '401 Unauthorized, already retried, maybe logout then login'
+        );
       }
+    }
+    if (!response.ok) {
+      const result = await response.json();
+      console.warn('libraryApiGetAlbums - fetch not ok.');
+      console.debug('libraryApiGetAlbums - fetch not ok:', {
+        responseJson: result,
+        response: response,
+      });
+      // Throw a StatusError if a non-OK HTTP status was returned.
+      let message = '';
+      try {
+        // Try to parse the response body as JSON, in case the server returned a useful response.
+        message = await response.json();
+      } catch (err) {
+        // Ignore if no JSON payload was retrieved and use the status text instead.
+      }
+      throw new Error(`${response.status} ${response.statusText} ${message}`);
+    }
+    return response;
+  };
 
-      // Loop until all albums have been listed and no new nextPageToken is
-      // returned.
-    } while (parameters.has('pageToken'));
-  } catch (err) {
-    // Log the error and prepare to return it.
-    ret.error = JSON.stringify(err);
-    console.error(JSON.stringify({ 'libraryApiGetAlbums Error': err }));
-  }
+  /*
+   * @description Uses refresh_token to get a new access_token.
+   * @returns {boolean} true if successfully updated access_token
+   */
 
-  console.debug(
-    JSON.stringify({ 'API response of first album': ret.albums[0] })
-  );
-  console.log(`${ret.albums.length} Albums loaded from Google Photos API`);
-  return ret;
+  refreshAccessToken = async (): Promise<boolean> => {
+    // https://developers.google.com/identity/protocols/oauth2/web-server#offline
+    const rawResponse = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: this.client_id,
+        client_secret: this.client_secret,
+        refresh_token: this.refresh_token,
+        grant_type: 'refresh_token',
+      }),
+    });
+    console.log('refreshAccessToken rawResponse', rawResponse);
+    const content = await rawResponse.json();
+    if (200 == rawResponse.status) {
+      this.access_token = content.access_token;
+      return true;
+    } else {
+      return false;
+    }
+  };
 }
 
 /*
@@ -118,7 +177,6 @@ export async function libraryApiGetAlbums(
  */
 export function getFakeAlbumsData(): GetAlbumsReturn {
   return {
-    statusCode: 200,
     albums: [
       {
         id: 'AC7OsWZSvKmd_BPEjRBdfHJ5K0MM4UdIqGjVgYLomvo7p7_ztWqDiMy4tSZuspFnS7z2E33Ny69t',

--- a/src/lib/googleApi.ts
+++ b/src/lib/googleApi.ts
@@ -107,27 +107,23 @@ export class PhotosApi {
         },
       }
     );
+    console.log('fetchAlbums status: ', response.status);
     if (401 == response.status) {
       // unauthorized
       if (this.authRetries--) {
-        console.log('fetchAlbums status is 401, trying refreshAccessToken');
         const isRefreshed = await this.refreshAccessToken();
         if (isRefreshed) {
           return await this.fetchAlbums(parameters);
         } else {
           throw new Error(
-            '401 Unauthorized, could refresh token, maybe logout then login'
+            '401 Unauthorized, could not refresh token, maybe logout then login'
           );
         }
       } else {
-        console.log('fetchAlbums status is 401, no refreshAccessToken');
         throw new Error(
           '401 Unauthorized, already retried, maybe logout then login'
         );
       }
-    } else {
-      console.log('fetchAlbums status is NOT 401');
-      await this.refreshAccessToken(); // TODO delme
     }
     if (!response.ok) {
       const result = await response.json();
@@ -136,15 +132,7 @@ export class PhotosApi {
         responseJson: result,
         response: response,
       });
-      // Throw a StatusError if a non-OK HTTP status was returned.
-      let message = '';
-      try {
-        // Try to parse the response body as JSON, in case the server returned a useful response.
-        message = await response.json();
-      } catch (err) {
-        // Ignore if no JSON payload was retrieved and use the status text instead.
-      }
-      throw new Error(`${response.status} ${response.statusText} ${message}`);
+      throw new Error(`${response.status} ${response.statusText} ${result}`);
     }
     return response;
   };

--- a/src/lib/googleApi.ts
+++ b/src/lib/googleApi.ts
@@ -106,6 +106,7 @@ export class PhotosApi {
     if (401 == response.status) {
       // unauthorized
       if (this.authRetries--) {
+        console.log('fetchAlbums status is 401, trying refreshAccessToken');
         const isRefreshed = await this.refreshAccessToken();
         if (isRefreshed) {
           return await this.fetchAlbums(parameters);
@@ -115,10 +116,13 @@ export class PhotosApi {
           );
         }
       } else {
+        console.log('fetchAlbums status is 401, no refreshAccessToken');
         throw new Error(
           '401 Unauthorized, already retried, maybe logout then login'
         );
       }
+    } else {
+      console.log('fetchAlbums status is NOT 401');
     }
     if (!response.ok) {
       const result = await response.json();

--- a/src/lib/googleApi.ts
+++ b/src/lib/googleApi.ts
@@ -94,9 +94,11 @@ export class PhotosApi {
     return ret;
   };
 
+  /*
+   * @description fetches albums info and will refresh access_token if need be
+   * @param {URLSearchParams} parameters - url parameters
+   */
   fetchAlbums = async (parameters: URLSearchParams): Promise<Response> => {
-    console.log('fetchAlbums parameters:', parameters);
-
     const response = await fetch(
       apiConfig.apiEndpoint + '/v1/albums?' + parameters,
       {
@@ -107,7 +109,6 @@ export class PhotosApi {
         },
       }
     );
-    console.log('fetchAlbums status: ', response.status);
     if (401 == response.status) {
       // unauthorized
       if (this.authRetries--) {
@@ -139,9 +140,9 @@ export class PhotosApi {
 
   /*
    * @description Uses refresh_token to get a new access_token.
+   * If authjs was not buggy, could do https://authjs.dev/guides/refresh-token-rotation
    * @returns {boolean} true if successfully updated access_token
    */
-
   refreshAccessToken = async (): Promise<boolean> => {
     // https://developers.google.com/identity/protocols/oauth2/web-server#offline
     const reqBody = {
@@ -159,7 +160,7 @@ export class PhotosApi {
       body: JSON.stringify(reqBody),
     });
     const content = await rawResponse.json();
-    console.log('refreshAccessToken', rawResponse, content, reqBody);
+    //console.log('refreshAccessToken', rawResponse, content, reqBody);
     if (200 == rawResponse.status) {
       this.access_token = content.access_token;
       return true;


### PR DESCRIPTION
# Description & Technical Solution

Problem: An hour after login, the albums page no longer can fetch data because `access_token` expired
Workaround: logout and login again

Solution: use `refresh_token` to get a new `access_token` so user does not have to logout and login again.
Note the `refresh_token` is returned from google during auth along with `access_token`

Solution implementation includes 
- adding `refresh_token` to the same places `access_token` was added, and passing both to the code that will call the Google Photos API.
- replacing a single function that calls the photos API with a class, and adding refresh token method to be called if photos API returns 401

# Checklist

- [/] I have commented my code, particularly in hard-to-understand areas.
- [/] Already rebased against main branch.

# Screenshots

Provide screenshots or videos of the changes made if any.
